### PR TITLE
Updates

### DIFF
--- a/output_results.py
+++ b/output_results.py
@@ -20,7 +20,7 @@ class Result(jc.DFTjob):
         jc.DFTjob.__init__(self, poscar)
         self.result = {}
         self.check_result()
-
+        self.completed = 0
     def check_result(self):
         print(self.path)
         for c in self.conf_lst:
@@ -69,13 +69,21 @@ class Result(jc.DFTjob):
 if __name__ == "__main__":
     poscars = glob.glob('poscars/*')
     os.system('squeue -u '+USER_name+' > current_running')
-
+    completed = 0
     output = {}
     
     for p in poscars:
         name = '_'.join(p.split('/')[1].split('_')[1:])
         d = Result(p)
         output[ name ] = d.result
-
+        if len(output[ name ]) == 4: 
+            completed += 1
+            sub_dirs = glob.glob(f'{name}/*')
+            for sub_dir in sub_dirs:
+                if sub_dir not in [f'{name}/rlx',f'{name}/rlx2',f'{name}/stc',f'{name}/POSCAR']: 
+                    shutil.rmtree(sub_dir)
+                    print(f'    Removed {sub_dir}')
     with open(os.path.basename(os.getcwd())+'_result.json', 'w') as f:
         json.dump(output, f, indent=4, ensure_ascii = False)
+
+    print('\n'+str(completed)+' finished.')

--- a/output_results.py
+++ b/output_results.py
@@ -29,7 +29,7 @@ class Result(jc.DFTjob):
                 return
             else:
                 os.chdir(cp)
-                out = subprocess.getoutput([os.path.join(self.global_path, 'check_converge.sh'), os.path.join(self.global_path, 'current_running')])
+                out = subprocess.check_output(['../../check_converge.sh','../../current_running']).decode("utf-8") 
                 if "True" in out:
                     os.chdir(self.global_path)
                     print("    ", c, " is converged")
@@ -62,8 +62,8 @@ class Result(jc.DFTjob):
         
         with open(ct, 'r') as f:
             dat = f.readlines()[2:5]
-            a1 = np.array(map(float, dat[0].strip().split()))
-            a2 = np.array(map(float, dat[1].strip().split()))
+            a1 = list(map(float, dat[0].strip().split()))
+            a2 = list(map(float, dat[1].strip().split()))
             return np.linalg.norm(np.cross(a1, a2))
 
 if __name__ == "__main__":

--- a/static_files/auto.q
+++ b/static_files/auto.q
@@ -3,10 +3,12 @@
 #SBATCH -N {nodes}
 #SBATCH -n {ntasks}
 #SBATCH -p {queuetype}
-#SBATCH -J autojob
+#SBATCH -J {name}
 #SBATCH -t {walltime}
 #SBATCH -A {key}
 #SBATCH -o job.oe
+#SBATCH --mail-type=END
+#SBATCH --mail-user=andrewlee1030quest@gmail.com
 
 #OpenMP settings:
 export OMP_NUM_THREADS=1


### PR DESCRIPTION
**job_control.py**

1. updated subprocess command to not return an error

2. Previously, you were allowed to restart a run (rlx, rlx2, stc) once, but if this restart was killed or ended without convergence, the next time you ran job_control.py, nothing would happen. So the following changes were made...

- restarts after the first restart will continue to generate even more backed up folders (rlx_bk_2, rlx_bk_3, ...)
- if the previously failed run made some progress on relaxing the structure (if CONTCAR exists), the next restart will use this previous CONTCAR as the next POSCAR to preserve the progress of the ionic steps. If no progress was made previously, the original POSCAR is reused.
-backups will continue until there are 10 backups, then the next time job_control.py is run, nothing will happen, and log.txt will show that something is wrong with the compound.

3. I changed the number of nodes and tasks and walltime, though this may not be necessary...

4. readouts from the code are now written straight to log.txt instead of being displayed on the screen... I thought this would be more useful so you can save the readout.

**output_results.py**

1. you cannot directly use np.array(*MAP OBJECT*) to get an array, you need to use list(*MAP OBJECT*) to successfully get a list (in this case, the list of floats). This has been fixed.

2. added a self.completed counter to count how many structures have been finished (will print to bottom of screen)

3. If a compound has been completed, the script will automatically delete all the backup directories for that compound and just keep the final rlx, rlx2, stc, and POSCAR files.
